### PR TITLE
feat: encap script testing with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.8-slim-buster
+
+WORKDIR /usr/src/app
+COPY . .
+
+# Install dependecy
+RUN apt update -y && apt install git -y
+RUN pip install --upgrade pip
+RUN pip3 install -r requirements.txt
+RUN pip3 install -r dev-requirements.txt
+
+# Run testing
+RUN pre-commit install && pre-commit install-hooks
+
+# Print results
+CMD pytest --verbose && pre-commit run --all-files

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,2 @@
-pytest
 pre-commit
+pytest


### PR DESCRIPTION
add docker support for Hela

for build image
```sh
docker build -t my-python-image .
```
running image
```sh
docker run my-python-image
```
use a pre-built Docker image to run python
```sh
docker run -it python:3.8
```